### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -62,3 +62,19 @@ editor:
   parameters:
     - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/jenkins"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddJenkinsfileWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.54"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "master"
+    sha: "6eb1e16"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/jenkins"
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,66 @@
+import groovy.json.JsonOutput
+
+/*
+ * Retrieve current SCM information from local checkout
+ */
+def getSCMInformation() {
+    def gitRemoteUrl = sh(returnStdout: true, script: 'git config --get remote.origin.url').trim()
+    def gitCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    def gitBranchName = sh(returnStdout: true, script: 'git name-rev --always --name-only HEAD').trim().replace('remotes/origin/', '')
+
+    return [
+        url: gitRemoteUrl,
+        branch: gitBranchName,
+        commit: gitCommitSha
+    ]
+}
+
+/*
+ * Notify the Atomist services about the status of a build based from a
+ * git repository.
+ */
+def notifyAtomist(buildStatus, buildPhase="FINALIZED",
+                  endpoint="https://webhook.atomist.com") {
+
+    def payload = JsonOutput.toJson([
+        name: env.JOB_NAME,
+        duration: currentBuild.duration,
+        build      : [
+            number: env.BUILD_NUMBER,
+            phase: buildPhase,
+            status: buildStatus,
+            full_url: env.BUILD_URL,
+            scm: getSCMInformation()
+        ]
+    ])
+
+    sh "curl --silent -XPOST -H 'Content-Type: application/json' -d '${payload}' ${endpoint}"
+}
 pipeline {
     agent any
     stages {
         stage('Checkout') {
             steps {
                 checkout scm
-            }
+               notifyAtomist("STARTED", "STARTED")
+                }
         }
         stage('Build') {
             steps {
                 sleep 20
                 echo "built"
             }
+        }
+    }
+    post {
+        success {
+            notifyAtomist("SUCCESS")
+        }
+        unstable {
+            notifyAtomist("UNSTABLE")
+        }
+        failure {
+            notifyAtomist("FAILURE")
         }
     }
 }


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in #sylvain-test4 in Slack.

[Atomist jenkinsfile documentation](http://docs.atomist.com/getting-started/jenkins/#jenkinsfile)